### PR TITLE
Day 1: Add Users & Auth foundation (JWT, bcrypt, Mongoose, DTOs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+MONGO_URI=mongodb://localhost:27017/social_api
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRES_IN=7d
+PORT=3000

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AuthModule } from './auth/auth.module';
+import { UsersModule } from './users/users.module';
+
+@Module({
+  imports: [
+    MongooseModule.forRoot(process.env.MONGO_URI ?? ''),
+    UsersModule,
+    AuthModule,
+  ],
+})
+export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Post, Request, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  register(@Body() dto: RegisterDto) {
+    return this.authService.register(dto);
+  }
+
+  @Post('login')
+  login(@Body() dto: LoginDto) {
+    return this.authService.login(dto.email, dto.password);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Get('me')
+  me(@Request() req: { user: { sub: string } }) {
+    return this.authService.getMe(req.user.sub);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { UsersModule } from '../users/users.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './jwt.strategy';
+
+@Module({
+  imports: [
+    UsersModule,
+    PassportModule,
+    JwtModule.registerAsync({
+      useFactory: () => ({
+        secret: process.env.JWT_SECRET,
+        signOptions: { expiresIn: process.env.JWT_EXPIRES_IN },
+      }),
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,56 @@
+import { ConflictException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+import { UsersService } from '../users/users.service';
+import { RegisterDto } from './dto/register.dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async register(dto: RegisterDto) {
+    const existingUser = await this.usersService.findByEmail(dto.email);
+    if (existingUser) {
+      throw new ConflictException('Email already in use');
+    }
+
+    const passwordHash = await bcrypt.hash(dto.password, 10);
+    const user = await this.usersService.createUser({
+      name: dto.name,
+      email: dto.email,
+      passwordHash,
+    });
+
+    return user.toJSON();
+  }
+
+  async login(email: string, password: string) {
+    const user = await this.usersService.findByEmail(email, true);
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const token = await this.jwtService.signAsync({
+      sub: user.id,
+      email: user.email,
+    });
+
+    return { token };
+  }
+
+  async getMe(userId: string) {
+    const user = await this.usersService.findById(userId);
+    if (!user) {
+      throw new UnauthorizedException('Invalid token');
+    }
+    return user.toJSON();
+  }
+}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  password: string;
+}

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @IsString()
+  @MinLength(2)
+  name: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET,
+    });
+  }
+
+  validate(payload: { sub: string; email: string }) {
+    return payload;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,20 @@
+import 'dotenv/config';
+import { ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
+  const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+  await app.listen(port);
+}
+
+bootstrap();

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -1,0 +1,32 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type UserDocument = HydratedDocument<User>;
+
+@Schema({
+  timestamps: true,
+  toJSON: {
+    transform: (_doc, ret) => {
+      delete ret.passwordHash;
+      return ret;
+    },
+  },
+})
+export class User {
+  @Prop({ required: true, trim: true })
+  name: string;
+
+  @Prop({
+    required: true,
+    unique: true,
+    lowercase: true,
+    trim: true,
+    index: true,
+  })
+  email: string;
+
+  @Prop({ required: true, select: false })
+  passwordHash: string;
+}
+
+export const UserSchema = SchemaFactory.createForClass(User);

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { User, UserSchema } from './schemas/user.schema';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: User.name, schema: UserSchema }])],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User, UserDocument } from './schemas/user.schema';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+  ) {}
+
+  findByEmail(email: string, includePassword = false) {
+    const query = this.userModel.findOne({ email });
+    if (includePassword) {
+      return query.select('+passwordHash');
+    }
+    return query;
+  }
+
+  findById(id: string) {
+    return this.userModel.findById(id);
+  }
+
+  createUser({
+    name,
+    email,
+    passwordHash,
+  }: {
+    name: string;
+    email: string;
+    passwordHash: string;
+  }) {
+    const createdUser = new this.userModel({ name, email, passwordHash });
+    return createdUser.save();
+  }
+}


### PR DESCRIPTION
### Motivation
- Bootstraps a Day 1 backend foundation for a social app implementing user registration, login, and a protected `GET /auth/me` endpoint. 
- Provide secure password hashing, JWT authentication, and DTO validation so the API is ready for integration and future features.

### Description
- Add `.env.example` and load environment variables early with `import 'dotenv/config'` in `src/main.ts`, and enable a global `ValidationPipe` configured with `whitelist`, `forbidNonWhitelisted`, and `transform`.
- Wire MongoDB via `MongooseModule.forRoot(process.env.MONGO_URI)` in `src/app.module.ts` and add a Mongoose `User` schema at `src/users/schemas/user.schema.ts` with `name`, `email`, and `passwordHash`, `timestamps`, `email` indexing, `passwordHash` excluded from outputs (`select: false` and removed in `toJSON`).
- Implement `UsersModule` and `UsersService` with `findByEmail`, `findById`, and `createUser` methods in `src/users/*`.
- Implement `AuthModule` with `JwtModule` using `JWT_SECRET` and `JWT_EXPIRES_IN`, a `JwtStrategy` that reads tokens from `Authorization: Bearer <token>`, DTOs `RegisterDto` and `LoginDto` for validation, `AuthService` that hashes passwords with `bcrypt`, issues JWTs with payload `{ sub, email }`, and throws `ConflictException` / `UnauthorizedException` as required, and `AuthController` exposing `POST /auth/register`, `POST /auth/login`, and protected `GET /auth/me`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e83b1cac8324baa17c11335274b1)