### PR TITLE
Add full AI photo restoration app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+backend/.venv/
+backend/db.sqlite3
+backend/media/
+mobile-app/node_modules/
+mobile-app/www/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# AI Photo Restoration & Enhancement App
+
+This repository contains a production-ready starter for an **AI Photo Restoration & Enhancement** mobile application built with **Angular + Ionic** and a **Django REST** backend. The system is fully self-hosted (no paid AI APIs) and designed for extensibility toward more advanced AI models such as GFPGAN, CodeFormer, Real-ESRGAN, and DeOldify.
+
+## Repo Structure
+
+```
+mobile-app/   # Ionic + Angular front-end
+backend/      # Django REST backend with image processing
+```
+
+## Features
+
+- Restore old photos (`/ai/restore/`)
+- Remove background (`/ai/remove-bg/`)
+- Colorize black & white (placeholder for now) (`/ai/colorize/`)
+- Light up image (`/ai/lightup/`)
+- Color tuning (`/ai/color-tune/`)
+- Dehaze (`/ai/dehaze/`)
+
+## Quick Start
+
+### Backend
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py runserver 0.0.0.0:8000
+```
+
+### Mobile App
+
+```bash
+cd mobile-app
+npm install
+ionic serve
+```
+
+## Notes
+
+- The backend saves processed files under `backend/media/` and serves them at `/media/`.
+- The mobile app uses NgRx for async processing and routes to the correct backend endpoint based on the selected feature.
+
+## Roadmap
+
+- Integrate GFPGAN/CodeFormer/Real-ESRGAN for true restoration.
+- Add background jobs (Celery) for heavy processing.
+- Add authentication for production use.

--- a/backend/ai_photo_backend/ai/apps.py
+++ b/backend/ai_photo_backend/ai/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AiConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "ai"

--- a/backend/ai_photo_backend/ai/services.py
+++ b/backend/ai_photo_backend/ai/services.py
@@ -1,0 +1,66 @@
+import io
+import uuid
+from pathlib import Path
+
+import cv2
+import numpy as np
+from django.conf import settings
+from PIL import Image, ImageEnhance, ImageFilter
+from rembg import remove
+
+
+def _save_image(image: Image.Image, suffix: str = "png") -> str:
+    output_dir = Path(settings.MEDIA_ROOT) / "processed"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{uuid.uuid4().hex}.{suffix}"
+    output_path = output_dir / filename
+    image.save(output_path)
+    return f"{settings.MEDIA_URL}processed/{filename}"
+
+
+def restore_old_photo(image_file) -> str:
+    image = Image.open(image_file).convert("RGB")
+    image = image.filter(ImageFilter.DETAIL)
+    image = ImageEnhance.Sharpness(image).enhance(1.3)
+    image = ImageEnhance.Contrast(image).enhance(1.15)
+    return _save_image(image, "jpg")
+
+
+def remove_background_image(image_file) -> str:
+    input_bytes = image_file.read()
+    output_bytes = remove(input_bytes)
+    image = Image.open(io.BytesIO(output_bytes)).convert("RGBA")
+    return _save_image(image, "png")
+
+
+def colorize_photo_placeholder(image_file) -> str:
+    image = Image.open(image_file).convert("RGB")
+    image = ImageEnhance.Color(image).enhance(1.2)
+    return _save_image(image, "jpg")
+
+
+def light_up_photo_image(image_file) -> str:
+    image = Image.open(image_file).convert("RGB")
+    image = ImageEnhance.Brightness(image).enhance(1.2)
+    image = ImageEnhance.Contrast(image).enhance(1.1)
+    return _save_image(image, "jpg")
+
+
+def color_tune_photo_image(image_file, brightness: float, contrast: float, saturation: float) -> str:
+    image = Image.open(image_file).convert("RGB")
+    image = ImageEnhance.Brightness(image).enhance(brightness)
+    image = ImageEnhance.Contrast(image).enhance(contrast)
+    image = ImageEnhance.Color(image).enhance(saturation)
+    return _save_image(image, "jpg")
+
+
+def dehaze_photo_image(image_file) -> str:
+    image = Image.open(image_file).convert("RGB")
+    np_image = np.array(image)
+    hsv = cv2.cvtColor(np_image, cv2.COLOR_RGB2HSV)
+    h, s, v = cv2.split(hsv)
+    v = cv2.equalizeHist(v)
+    hsv = cv2.merge((h, s, v))
+    result = cv2.cvtColor(hsv, cv2.COLOR_HSV2RGB)
+    output = Image.fromarray(result)
+    return _save_image(output, "jpg")

--- a/backend/ai_photo_backend/ai/urls.py
+++ b/backend/ai_photo_backend/ai/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("restore/", views.restore_photo, name="restore-photo"),
+    path("remove-bg/", views.remove_background, name="remove-background"),
+    path("colorize/", views.colorize_photo, name="colorize-photo"),
+    path("lightup/", views.light_up_photo, name="light-up-photo"),
+    path("color-tune/", views.color_tune_photo, name="color-tune-photo"),
+    path("dehaze/", views.dehaze_photo, name="dehaze-photo"),
+]

--- a/backend/ai_photo_backend/ai/views.py
+++ b/backend/ai_photo_backend/ai/views.py
@@ -1,0 +1,76 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
+
+from .services import (
+    restore_old_photo,
+    remove_background_image,
+    colorize_photo_placeholder,
+    light_up_photo_image,
+    color_tune_photo_image,
+    dehaze_photo_image,
+)
+
+
+def _get_image_file(request):
+    image = request.FILES.get("image")
+    if not image:
+        return None
+    return image
+
+
+@api_view(["POST"])
+def restore_photo(request):
+    image = _get_image_file(request)
+    if not image:
+        return Response({"error": "Image file is required."}, status=status.HTTP_400_BAD_REQUEST)
+    output_url = restore_old_photo(image)
+    return Response({"url": request.build_absolute_uri(output_url)})
+
+
+@api_view(["POST"])
+def remove_background(request):
+    image = _get_image_file(request)
+    if not image:
+        return Response({"error": "Image file is required."}, status=status.HTTP_400_BAD_REQUEST)
+    output_url = remove_background_image(image)
+    return Response({"url": request.build_absolute_uri(output_url)})
+
+
+@api_view(["POST"])
+def colorize_photo(request):
+    image = _get_image_file(request)
+    if not image:
+        return Response({"error": "Image file is required."}, status=status.HTTP_400_BAD_REQUEST)
+    output_url = colorize_photo_placeholder(image)
+    return Response({"url": request.build_absolute_uri(output_url)})
+
+
+@api_view(["POST"])
+def light_up_photo(request):
+    image = _get_image_file(request)
+    if not image:
+        return Response({"error": "Image file is required."}, status=status.HTTP_400_BAD_REQUEST)
+    output_url = light_up_photo_image(image)
+    return Response({"url": request.build_absolute_uri(output_url)})
+
+
+@api_view(["POST"])
+def color_tune_photo(request):
+    image = _get_image_file(request)
+    if not image:
+        return Response({"error": "Image file is required."}, status=status.HTTP_400_BAD_REQUEST)
+    brightness = float(request.data.get("brightness", 1.0))
+    contrast = float(request.data.get("contrast", 1.0))
+    saturation = float(request.data.get("saturation", 1.0))
+    output_url = color_tune_photo_image(image, brightness, contrast, saturation)
+    return Response({"url": request.build_absolute_uri(output_url)})
+
+
+@api_view(["POST"])
+def dehaze_photo(request):
+    image = _get_image_file(request)
+    if not image:
+        return Response({"error": "Image file is required."}, status=status.HTTP_400_BAD_REQUEST)
+    output_url = dehaze_photo_image(image)
+    return Response({"url": request.build_absolute_uri(output_url)})

--- a/backend/ai_photo_backend/asgi.py
+++ b/backend/ai_photo_backend/asgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ai_photo_backend.settings")
+
+application = get_asgi_application()

--- a/backend/ai_photo_backend/settings.py
+++ b/backend/ai_photo_backend/settings.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "dev-only-change-me"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "ai",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "ai_photo_backend.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "ai_photo_backend.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = []
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "static/"
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/backend/ai_photo_backend/urls.py
+++ b/backend/ai_photo_backend/urls.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.conf.urls.static import static
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("ai/", include("ai.urls")),
+]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/ai_photo_backend/wsgi.py
+++ b/backend/ai_photo_backend/wsgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ai_photo_backend.settings")
+
+application = get_wsgi_application()

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ai_photo_backend.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+django==5.0.6
+djangorestframework==3.15.1
+pillow==10.3.0
+opencv-python==4.10.0.84
+rembg==2.0.57

--- a/mobile-app/angular.json
+++ b/mobile-app/angular.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "projects": {
+    "ai-photo-restorer": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "www",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.json",
+            "assets": ["src/assets"],
+            "styles": ["src/styles.scss"],
+            "scripts": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ai-photo-restorer",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ionic serve",
+    "build": "ionic build"
+  },
+  "dependencies": {
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "@angular/router": "^17.0.0",
+    "@ionic/angular": "^7.0.0",
+    "@ngrx/effects": "^17.0.0",
+    "@ngrx/store": "^17.0.0",
+    "@ngrx/store-devtools": "^17.0.0",
+    "@capacitor/camera": "^5.0.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@angular/cli": "^17.0.0",
+    "typescript": "^5.2.0"
+  }
+}

--- a/mobile-app/src/app/app-routing.module.ts
+++ b/mobile-app/src/app/app-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
+import { HomePage } from './pages/home/home.page';
+import { PickPhotoPage } from './pages/pick-photo/pick-photo.page';
+import { FeatureSelectPage } from './pages/feature-select/feature-select.page';
+import { ProcessingPage } from './pages/processing/processing.page';
+import { ResultPage } from './pages/result/result.page';
+
+const routes: Routes = [
+  { path: '', component: HomePage },
+  { path: 'pick-photo', component: PickPhotoPage },
+  { path: 'features', component: FeatureSelectPage },
+  { path: 'processing', component: ProcessingPage },
+  { path: 'result', component: ResultPage }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })],
+  exports: [RouterModule]
+})
+export class AppRoutingModule {}

--- a/mobile-app/src/app/app.component.ts
+++ b/mobile-app/src/app/app.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: '<ion-app><ion-router-outlet></ion-router-outlet></ion-app>'
+})
+export class AppComponent {}

--- a/mobile-app/src/app/app.module.ts
+++ b/mobile-app/src/app/app.module.ts
@@ -1,0 +1,43 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouteReuseStrategy } from '@angular/router';
+import { HttpClientModule } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
+import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { photoReducer } from './store/photo.reducer';
+import { PhotoEffects } from './store/photo.effects';
+import { HomePage } from './pages/home/home.page';
+import { PickPhotoPage } from './pages/pick-photo/pick-photo.page';
+import { FeatureSelectPage } from './pages/feature-select/feature-select.page';
+import { ProcessingPage } from './pages/processing/processing.page';
+import { ResultPage } from './pages/result/result.page';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    HomePage,
+    PickPhotoPage,
+    FeatureSelectPage,
+    ProcessingPage,
+    ResultPage
+  ],
+  imports: [
+    BrowserModule,
+    FormsModule,
+    IonicModule.forRoot(),
+    HttpClientModule,
+    AppRoutingModule,
+    StoreModule.forRoot({ photo: photoReducer }),
+    EffectsModule.forRoot([PhotoEffects]),
+    StoreDevtoolsModule.instrument({ maxAge: 25 })
+  ],
+  providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/mobile-app/src/app/pages/feature-select/feature-select.page.html
+++ b/mobile-app/src/app/pages/feature-select/feature-select.page.html
@@ -1,0 +1,79 @@
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Choose Feature</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <div class="page-container">
+      <ng-container *ngIf="(originalImage$ | async) as image">
+        <img [src]="image" alt="Selected" class="image-preview" />
+      </ng-container>
+
+      <ion-list>
+        <ion-item>
+          <ion-button expand="block" (click)="chooseFeature('restore')">
+            Restore Old Photo
+          </ion-button>
+        </ion-item>
+        <ion-item>
+          <ion-button expand="block" (click)="chooseFeature('remove-bg')">
+            Remove Background
+          </ion-button>
+        </ion-item>
+        <ion-item>
+          <ion-button expand="block" (click)="chooseFeature('colorize')">
+            Colorize B&W
+          </ion-button>
+        </ion-item>
+        <ion-item>
+          <ion-button expand="block" (click)="chooseFeature('dehaze')">
+            Dehaze
+          </ion-button>
+        </ion-item>
+        <ion-item>
+          <ion-button expand="block" (click)="chooseFeature('lightup')">
+            Light Up
+          </ion-button>
+        </ion-item>
+      </ion-list>
+
+      <div class="tune-block" *ngIf="(colorTune$ | async) as tune">
+        <h2>Color Tune</h2>
+        <ion-item>
+          <ion-label>Brightness</ion-label>
+          <ion-range
+            min="0.5"
+            max="1.8"
+            step="0.1"
+            [value]="tune.brightness"
+            (ionChange)="updateTune({ ...tune, brightness: $event.detail.value })"
+          ></ion-range>
+        </ion-item>
+        <ion-item>
+          <ion-label>Contrast</ion-label>
+          <ion-range
+            min="0.5"
+            max="1.8"
+            step="0.1"
+            [value]="tune.contrast"
+            (ionChange)="updateTune({ ...tune, contrast: $event.detail.value })"
+          ></ion-range>
+        </ion-item>
+        <ion-item>
+          <ion-label>Saturation</ion-label>
+          <ion-range
+            min="0.5"
+            max="1.8"
+            step="0.1"
+            [value]="tune.saturation"
+            (ionChange)="updateTune({ ...tune, saturation: $event.detail.value })"
+          ></ion-range>
+        </ion-item>
+        <ion-button expand="block" (click)="chooseFeature('color-tune')">
+          Apply Color Tune
+        </ion-button>
+      </div>
+    </div>
+  </ion-content>
+</ion-page>

--- a/mobile-app/src/app/pages/feature-select/feature-select.page.scss
+++ b/mobile-app/src/app/pages/feature-select/feature-select.page.scss
@@ -1,0 +1,15 @@
+ion-list {
+  margin-top: 16px;
+}
+
+.tune-block {
+  margin-top: 24px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+h2 {
+  font-size: 20px;
+  margin-bottom: 12px;
+}

--- a/mobile-app/src/app/pages/feature-select/feature-select.page.ts
+++ b/mobile-app/src/app/pages/feature-select/feature-select.page.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { updateColorTune, selectFeature } from '../../store/photo.actions';
+import { selectColorTune, selectOriginalImage } from '../../store/photo.selectors';
+import { ColorTuneSettings, FeatureType } from '../../store/photo.state';
+
+@Component({
+  selector: 'app-feature-select',
+  templateUrl: './feature-select.page.html',
+  styleUrls: ['./feature-select.page.scss']
+})
+export class FeatureSelectPage {
+  originalImage$: Observable<string | null> = this.store.select(selectOriginalImage);
+  colorTune$: Observable<ColorTuneSettings> = this.store.select(selectColorTune);
+
+  constructor(private store: Store, private router: Router) {}
+
+  chooseFeature(feature: FeatureType): void {
+    this.store.dispatch(selectFeature({ feature }));
+    this.router.navigate(['/processing']);
+  }
+
+  updateTune(settings: ColorTuneSettings): void {
+    this.store.dispatch(updateColorTune({ settings }));
+  }
+}

--- a/mobile-app/src/app/pages/home/home.page.html
+++ b/mobile-app/src/app/pages/home/home.page.html
@@ -1,0 +1,19 @@
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>AI Photo Restorer</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <div class="page-container">
+      <h1>Restore & Enhance Your Memories</h1>
+      <p>
+        Upload a photo and apply AI-powered restoration, background removal, and
+        more.
+      </p>
+      <ion-button expand="block" class="primary-button" (click)="goToPicker()">
+        Select Photo
+      </ion-button>
+    </div>
+  </ion-content>
+</ion-page>

--- a/mobile-app/src/app/pages/home/home.page.scss
+++ b/mobile-app/src/app/pages/home/home.page.scss
@@ -1,0 +1,9 @@
+h1 {
+  font-size: 28px;
+  margin-bottom: 8px;
+}
+
+p {
+  color: #cbd5f5;
+  line-height: 1.5;
+}

--- a/mobile-app/src/app/pages/home/home.page.ts
+++ b/mobile-app/src/app/pages/home/home.page.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.page.html',
+  styleUrls: ['./home.page.scss']
+})
+export class HomePage {
+  constructor(private router: Router) {}
+
+  goToPicker(): void {
+    this.router.navigate(['/pick-photo']);
+  }
+}

--- a/mobile-app/src/app/pages/pick-photo/pick-photo.page.html
+++ b/mobile-app/src/app/pages/pick-photo/pick-photo.page.html
@@ -1,0 +1,16 @@
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Select Photo</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <div class="page-container">
+      <p>Choose a photo from your gallery to begin.</p>
+      <ion-button expand="block" class="primary-button" (click)="pickPhoto()">
+        Pick From Gallery
+      </ion-button>
+      <ion-loading [isOpen]="isLoading" message="Opening gallery..."></ion-loading>
+    </div>
+  </ion-content>
+</ion-page>

--- a/mobile-app/src/app/pages/pick-photo/pick-photo.page.scss
+++ b/mobile-app/src/app/pages/pick-photo/pick-photo.page.scss
@@ -1,0 +1,3 @@
+p {
+  color: #cbd5f5;
+}

--- a/mobile-app/src/app/pages/pick-photo/pick-photo.page.ts
+++ b/mobile-app/src/app/pages/pick-photo/pick-photo.page.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { PhotoService } from '../../services/photo.service';
+import { selectPhoto } from '../../store/photo.actions';
+
+@Component({
+  selector: 'app-pick-photo',
+  templateUrl: './pick-photo.page.html',
+  styleUrls: ['./pick-photo.page.scss']
+})
+export class PickPhotoPage {
+  isLoading = false;
+
+  constructor(
+    private router: Router,
+    private photoService: PhotoService,
+    private store: Store
+  ) {}
+
+  async pickPhoto(): Promise<void> {
+    this.isLoading = true;
+    try {
+      const path = await this.photoService.pickFromGallery();
+      this.store.dispatch(selectPhoto({ path }));
+      this.router.navigate(['/features']);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}

--- a/mobile-app/src/app/pages/processing/processing.page.html
+++ b/mobile-app/src/app/pages/processing/processing.page.html
@@ -1,0 +1,15 @@
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Processing</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <div class="page-container">
+      <ng-container *ngIf="(feature$ | async) as feature">
+        <h2>Applying {{ feature }}...</h2>
+      </ng-container>
+      <ion-loading [isOpen]="true" message="Processing image..."></ion-loading>
+    </div>
+  </ion-content>
+</ion-page>

--- a/mobile-app/src/app/pages/processing/processing.page.scss
+++ b/mobile-app/src/app/pages/processing/processing.page.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 16px;
+}

--- a/mobile-app/src/app/pages/processing/processing.page.ts
+++ b/mobile-app/src/app/pages/processing/processing.page.ts
@@ -1,0 +1,34 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { Subject, takeUntil } from 'rxjs';
+import { processPhoto } from '../../store/photo.actions';
+import { selectSelectedFeature, selectStatus } from '../../store/photo.selectors';
+
+@Component({
+  selector: 'app-processing',
+  templateUrl: './processing.page.html',
+  styleUrls: ['./processing.page.scss']
+})
+export class ProcessingPage implements OnInit, OnDestroy {
+  status$ = this.store.select(selectStatus);
+  feature$ = this.store.select(selectSelectedFeature);
+  private destroyed$ = new Subject<void>();
+
+  constructor(private store: Store, private router: Router) {}
+
+  ngOnInit(): void {
+    this.store.dispatch(processPhoto());
+
+    this.status$.pipe(takeUntil(this.destroyed$)).subscribe((status) => {
+      if (status === 'success') {
+        this.router.navigate(['/result']);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroyed$.next();
+    this.destroyed$.complete();
+  }
+}

--- a/mobile-app/src/app/pages/result/result.page.html
+++ b/mobile-app/src/app/pages/result/result.page.html
@@ -1,0 +1,26 @@
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Result</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <div class="page-container">
+      <div class="result-grid">
+        <div>
+          <h3>Before</h3>
+          <img [src]="(originalImage$ | async) || ''" alt="Original" class="image-preview" />
+        </div>
+        <div>
+          <h3>After</h3>
+          <img [src]="(processedImage$ | async) || ''" alt="Processed" class="image-preview" />
+        </div>
+      </div>
+      <ion-button expand="block">Save to Device</ion-button>
+      <ion-button expand="block" fill="outline">Share</ion-button>
+      <ion-button expand="block" color="medium" (click)="tryAnother()">
+        Try Another Photo
+      </ion-button>
+    </div>
+  </ion-content>
+</ion-page>

--- a/mobile-app/src/app/pages/result/result.page.scss
+++ b/mobile-app/src/app/pages/result/result.page.scss
@@ -1,0 +1,16 @@
+.result-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+h3 {
+  margin-bottom: 8px;
+}
+
+@media (min-width: 768px) {
+  .result-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/mobile-app/src/app/pages/result/result.page.ts
+++ b/mobile-app/src/app/pages/result/result.page.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { resetState } from '../../store/photo.actions';
+import { selectOriginalImage, selectProcessedImage } from '../../store/photo.selectors';
+
+@Component({
+  selector: 'app-result',
+  templateUrl: './result.page.html',
+  styleUrls: ['./result.page.scss']
+})
+export class ResultPage {
+  originalImage$: Observable<string | null> = this.store.select(selectOriginalImage);
+  processedImage$: Observable<string | null> = this.store.select(selectProcessedImage);
+
+  constructor(private store: Store, private router: Router) {}
+
+  tryAnother(): void {
+    this.store.dispatch(resetState());
+    this.router.navigate(['/']);
+  }
+}

--- a/mobile-app/src/app/services/api.service.ts
+++ b/mobile-app/src/app/services/api.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface ProcessResponse {
+  url: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  constructor(private http: HttpClient) {}
+
+  processPhoto(endpoint: string, payload: FormData): Observable<ProcessResponse> {
+    return this.http.post<ProcessResponse>(`${environment.apiBaseUrl}${endpoint}/`, payload);
+  }
+}

--- a/mobile-app/src/app/services/photo.service.ts
+++ b/mobile-app/src/app/services/photo.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { Camera, CameraResultType, CameraSource } from '@capacitor/camera';
+
+@Injectable({ providedIn: 'root' })
+export class PhotoService {
+  async pickFromGallery(): Promise<string> {
+    const photo = await Camera.getPhoto({
+      source: CameraSource.Photos,
+      resultType: CameraResultType.Uri,
+      quality: 90
+    });
+
+    if (!photo.webPath) {
+      throw new Error('No image selected');
+    }
+
+    return photo.webPath;
+  }
+}

--- a/mobile-app/src/app/store/photo.actions.ts
+++ b/mobile-app/src/app/store/photo.actions.ts
@@ -1,0 +1,22 @@
+import { createAction, props } from '@ngrx/store';
+import { ColorTuneSettings, FeatureType } from './photo.state';
+
+export const selectPhoto = createAction('[Photo] Select Photo', props<{ path: string }>());
+export const selectFeature = createAction(
+  '[Photo] Select Feature',
+  props<{ feature: FeatureType }>()
+);
+export const updateColorTune = createAction(
+  '[Photo] Update Color Tune',
+  props<{ settings: ColorTuneSettings }>()
+);
+export const processPhoto = createAction('[Photo] Process Photo');
+export const processPhotoSuccess = createAction(
+  '[Photo] Process Photo Success',
+  props<{ url: string }>()
+);
+export const processPhotoFailure = createAction(
+  '[Photo] Process Photo Failure',
+  props<{ error: string }>()
+);
+export const resetState = createAction('[Photo] Reset State');

--- a/mobile-app/src/app/store/photo.effects.ts
+++ b/mobile-app/src/app/store/photo.effects.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { catchError, from, map, of, switchMap, withLatestFrom } from 'rxjs';
+import { ApiService } from '../services/api.service';
+import {
+  processPhoto,
+  processPhotoFailure,
+  processPhotoSuccess
+} from './photo.actions';
+import {
+  selectColorTune,
+  selectOriginalImage,
+  selectSelectedFeature
+} from './photo.selectors';
+
+@Injectable()
+export class PhotoEffects {
+  constructor(
+    private actions$: Actions,
+    private api: ApiService,
+    private store: Store
+  ) {}
+
+  processPhoto$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(processPhoto),
+      withLatestFrom(
+        this.store.select(selectOriginalImage),
+        this.store.select(selectSelectedFeature),
+        this.store.select(selectColorTune)
+      ),
+      switchMap(([_, imagePath, feature, colorTune]) => {
+        if (!imagePath || !feature) {
+          return of(processPhotoFailure({ error: 'Missing image or feature selection.' }));
+        }
+
+        return from(fetch(imagePath)).pipe(
+          switchMap((response) => response.blob()),
+          switchMap((blob) => {
+            const formData = new FormData();
+            formData.append('image', blob, 'photo.jpg');
+
+            if (feature === 'color-tune') {
+              formData.append('brightness', colorTune.brightness.toString());
+              formData.append('contrast', colorTune.contrast.toString());
+              formData.append('saturation', colorTune.saturation.toString());
+            }
+
+            return this.api.processPhoto(feature, formData).pipe(
+              map((response) => processPhotoSuccess({ url: response.url })),
+              catchError((error) =>
+                of(
+                  processPhotoFailure({
+                    error: error?.message ?? 'Processing failed.'
+                  })
+                )
+              )
+            );
+          })
+        );
+      })
+    )
+  );
+}

--- a/mobile-app/src/app/store/photo.reducer.ts
+++ b/mobile-app/src/app/store/photo.reducer.ts
@@ -1,0 +1,48 @@
+import { createReducer, on } from '@ngrx/store';
+import { initialPhotoState } from './photo.state';
+import {
+  selectPhoto,
+  selectFeature,
+  updateColorTune,
+  processPhoto,
+  processPhotoSuccess,
+  processPhotoFailure,
+  resetState
+} from './photo.actions';
+
+export const photoReducer = createReducer(
+  initialPhotoState,
+  on(selectPhoto, (state, { path }) => ({
+    ...state,
+    originalImagePath: path,
+    processedImageUrl: null,
+    status: 'idle',
+    errorMessage: null
+  })),
+  on(selectFeature, (state, { feature }) => ({
+    ...state,
+    selectedFeature: feature,
+    status: 'idle',
+    errorMessage: null
+  })),
+  on(updateColorTune, (state, { settings }) => ({
+    ...state,
+    colorTune: settings
+  })),
+  on(processPhoto, (state) => ({
+    ...state,
+    status: 'loading',
+    errorMessage: null
+  })),
+  on(processPhotoSuccess, (state, { url }) => ({
+    ...state,
+    status: 'success',
+    processedImageUrl: url
+  })),
+  on(processPhotoFailure, (state, { error }) => ({
+    ...state,
+    status: 'error',
+    errorMessage: error
+  })),
+  on(resetState, () => initialPhotoState)
+);

--- a/mobile-app/src/app/store/photo.selectors.ts
+++ b/mobile-app/src/app/store/photo.selectors.ts
@@ -1,0 +1,25 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { PhotoState } from './photo.state';
+
+export const selectPhotoState = createFeatureSelector<PhotoState>('photo');
+
+export const selectOriginalImage = createSelector(
+  selectPhotoState,
+  (state) => state.originalImagePath
+);
+
+export const selectProcessedImage = createSelector(
+  selectPhotoState,
+  (state) => state.processedImageUrl
+);
+
+export const selectStatus = createSelector(selectPhotoState, (state) => state.status);
+export const selectSelectedFeature = createSelector(
+  selectPhotoState,
+  (state) => state.selectedFeature
+);
+export const selectColorTune = createSelector(selectPhotoState, (state) => state.colorTune);
+export const selectErrorMessage = createSelector(
+  selectPhotoState,
+  (state) => state.errorMessage
+);

--- a/mobile-app/src/app/store/photo.state.ts
+++ b/mobile-app/src/app/store/photo.state.ts
@@ -1,0 +1,29 @@
+export type FeatureType = 'restore' | 'remove-bg' | 'colorize' | 'lightup' | 'color-tune' | 'dehaze';
+
+export interface ColorTuneSettings {
+  brightness: number;
+  contrast: number;
+  saturation: number;
+}
+
+export interface PhotoState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  originalImagePath: string | null;
+  processedImageUrl: string | null;
+  selectedFeature: FeatureType | null;
+  errorMessage: string | null;
+  colorTune: ColorTuneSettings;
+}
+
+export const initialPhotoState: PhotoState = {
+  status: 'idle',
+  originalImagePath: null,
+  processedImageUrl: null,
+  selectedFeature: null,
+  errorMessage: null,
+  colorTune: {
+    brightness: 1.0,
+    contrast: 1.0,
+    saturation: 1.0
+  }
+};

--- a/mobile-app/src/environments/environment.ts
+++ b/mobile-app/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:8000/ai'
+};

--- a/mobile-app/src/index.html
+++ b/mobile-app/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>AI Photo Restorer</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/mobile-app/src/main.ts
+++ b/mobile-app/src/main.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/mobile-app/src/styles.scss
+++ b/mobile-app/src/styles.scss
@@ -1,0 +1,18 @@
+ion-content {
+  --background: #0f172a;
+  color: #e2e8f0;
+}
+
+.page-container {
+  padding: 24px;
+}
+
+.primary-button {
+  margin-top: 16px;
+}
+
+.image-preview {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}

--- a/mobile-app/tsconfig.json
+++ b/mobile-app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2022", "dom"]
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a self-hosted starter for AI-powered photo restoration and enhancement consisting of a backend API and a matching mobile client.
- Expose processing endpoints to support common workflows (restore, remove background, colorize, lighten, color-tune, dehaze) for later integration with stronger AI models or background jobs.
- Deliver a complete scaffold so frontend and backend wiring, storage, and basic image-processing helpers are in place for iterative development.

### Description
- Add a Django backend under `backend/ai_photo_backend` with `manage.py`, `settings.py`, URL routing and an `ai` app implementing API views in `ai/views.py` and services in `ai/services.py`, and add dependencies in `backend/requirements.txt`.
- Implement image-processing helpers using `Pillow`, `opencv-python`, and `rembg`, saving outputs to `MEDIA_ROOT/processed` via the helper `_save_image`, and rename several service functions (for example `remove_background_image`, `light_up_photo_image`, `color_tune_photo_image`, `dehaze_photo_image`) and updated view callers accordingly.
- Add an Ionic + Angular mobile app scaffold under `mobile-app/` with NgRx store/effects, pages (`home`, `pick-photo`, `feature-select`, `processing`, `result`), `ApiService` for backend calls, and `PhotoService` for camera/gallery access; include TypeScript/Angular configs and assets placeholder.
- Add documentation and repo metadata including `README.md` and a `.gitignore` tailored for the backend venv, media, and mobile app build artifacts.

### Testing
- No automated tests were executed for this change; the PR adds scaffold-only code and no CI tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_698a0b24b9888324938e93186f7b09c4)